### PR TITLE
Fix deploy to GitHub Pages

### DIFF
--- a/interaktiv-presentation/.github/workflows/deploy.yml
+++ b/interaktiv-presentation/.github/workflows/deploy.yml
@@ -1,26 +1,31 @@
 name: Deploy to GitHub Pages
 
-on: push: branches: - master # eller main, beroende på din branch
+on:
+  push:
+    branches:
+      - main
 
-jobs: build-deploy: runs-on: ubuntu-latest
+jobs:
+  build-deploy:
+    runs-on: ubuntu-latest
 
-steps:
-  - name: Checkout Repository
-    uses: actions/checkout@v3
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
 
-  - name: Setup Node.js
-    uses: actions/setup-node@v3
-    with:
-      node-version: '16'
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16'
 
-  - name: Install Dependencies
-    run: npm install
+      - name: Install Dependencies
+        run: npm install
 
-  - name: Build Project
-    run: npm run build
+      - name: Build Project
+        run: npm run build
 
-  - name: Deploy to GitHub Pages
-    uses: peaceiris/actions-gh-pages@v3
-    with:
-      github_token: ${{ secrets.GITHUB_TOKEN }}
-      publish_dir: ./build
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./build


### PR DESCRIPTION
Update GitHub Actions workflow to deploy to GitHub Pages on the main branch.

* Change the `on` section to trigger on the `main` branch instead of `master`.
* Ensure the `publish_dir` is set to `./build`.
* Reformat the workflow file for better readability.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/RoadlakeAnalytics/kronanpresentation?shareId=f1cd1f02-0e0b-4cc0-b019-1a49e7ad195e).